### PR TITLE
Fixes #19: Ignore ENOTSUP from Fallocate

### DIFF
--- a/protofile/file_linux.go
+++ b/protofile/file_linux.go
@@ -5,7 +5,6 @@ package protofile // import "blitznote.com/src/caddy.upload/protofile"
 
 import (
 	"os"
-	"syscall"
 )
 
 // Call this to discard the file.
@@ -43,11 +42,11 @@ func (p generalizedProtoFile) SizeWillBe(numBytes uint64) error {
 
 	fd := int(p.File.Fd())
 	if numBytes <= maxInt64 {
-		return syscall.Fallocate(fd, 0, 0, int64(numBytes))
+		return fallocate(fd, 0, int64(numBytes))
 	}
-	err := syscall.Fallocate(fd, 0, 0, maxInt64)
+	err := fallocate(fd, 0, maxInt64)
 	if err != nil {
 		return err
 	}
-	return syscall.Fallocate(fd, 0, maxInt64, int64(numBytes-maxInt64))
+	return fallocate(fd, maxInt64, int64(numBytes-maxInt64))
 }

--- a/protofile/util_linux.go
+++ b/protofile/util_linux.go
@@ -62,3 +62,14 @@ func fcntl(fd uintptr, cmd int, arg int) (val int, err error) {
 	}
 	return
 }
+
+// fallocate might fail with EOPNOTSUPP on filesystems that doesn't
+// support it, such as NFS. Still, we should not fail here.
+// This is used by SizeWillBe to optimize allocation.
+func fallocate(fd uintptr, off int64, len int64) (err error) {
+	err := syscall.Fallocate(fd, 0, off, len)
+	if err == syscall.EOPNOTSUPP {
+		return nil
+	}
+	return err
+}


### PR DESCRIPTION
Linux with a mounted NFS filesystem doesn't support the fallocate syscall, which result in the request failing with status 500. The fix is simple: SizeWillBe should not fail at all if the error from fallocate is ENOTSUP.

Fixes #19